### PR TITLE
add non root user with id 1001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,6 @@ RUN git clone https://github.com/AGWA/git-crypt.git ~/builder/git/git-crypt
 RUN cd ~/builder/git/git-crypt && make && make install
 
 RUN rc-update add docker boot
+
+ARG UID=1001
+RUN addgroup -g ${UID} -S appgroup && adduser -u ${UID} -S appuser -G appgroup


### PR DESCRIPTION
- this allows commands to be ran as non root user
- this is a policy enforced by the cloud platform cluster