### PR TITLE
Add jq package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add openssl-dev
 RUN apk add ruby
 RUN apk add python3
 RUN apk add py3-pip
+RUN apk add jq
 RUN pip3 install --upgrade pip
 RUN pip3 install --ignore-installed awscli
 


### PR DESCRIPTION
The jq is used in the acceptance test script in the baseline deploy
repo https://github.com/ministryofjustice/fb-deploy/blob/master/bin/acceptance_tests