### PR TITLE
Add curl for acceptance test script on fb-deploy repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add ruby
 RUN apk add python3
 RUN apk add py3-pip
 RUN apk add jq
+RUN apk add curl
 RUN pip3 install --upgrade pip
 RUN pip3 install --ignore-installed awscli
 


### PR DESCRIPTION
Curl is used on acceptance test script, so needs to be added on fb-builder