### PR TITLE
Use Kubernetes 1.18.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  aws-ecr: circleci/aws-ecr@6.7.0
+  aws-ecr: circleci/aws-ecr@7.0.0
 version: 2.1
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install --ignore-installed awscli
 RUN rm -rf /var/cache/apk/*
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.17.8/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.18.18/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 
 RUN chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
Cloud Platform have moved to use Kubernetes 1.18.18 so we should also
update this use the same version