### PR TITLE
Update Kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,12 @@ FROM alpine:latest
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/latest-stable/main" >> /etc/apk/repositories
 
 RUN apk update
-RUN apk add --no-cache bash build-base curl docker docker-compose git git-crypt make nodejs npm openrc openssh openssl-dev
-RUN apk --no-cache add ruby ruby-dev helm
+RUN apk add --no-cache bash build-base curl docker docker-compose git git-crypt \
+    make nodejs npm openrc openssh openssl-dev \
+    ruby ruby-dev helm python3 py3-pip jq kubectl
 RUN gem install bundler
-RUN apk add python3 py3-pip jq
 RUN pip3 install --ignore-installed --break-system-packages awscli
 RUN rm -rf /var/cache/apk/*
-
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin
 
 RUN mkdir -p ~/.ssh && \
     ssh-keyscan github.com > ~/.ssh/known_hosts


### PR DESCRIPTION
Trivy scan gave warnings for kubectl version used. Removed getting an old version of kubectl from a google build and replaced using the package manager. Trivy scan passed.